### PR TITLE
Add keyboard support for filters

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -90,6 +90,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           onClick={() => handleSortFieldClick("name")}
           title="Sort by Name"
           tabIndex={0}
+          role="button"
           aria-pressed={sortField === "name"}
           onKeyUp={(e) => e.key === "Enter" && handleSortFieldClick("name")}
         />
@@ -101,6 +102,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           onClick={() => handleSortFieldClick("stargazers_count")}
           title="Sort by Stargazers"
           tabIndex={0}
+          role="button"
           aria-pressed={sortField === "stargazers_count"}
           onKeyUp={(e) =>
             e.key === "Enter" && handleSortFieldClick("stargazers_count")
@@ -112,6 +114,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           onClick={() => handleSortFieldClick("updated_at")}
           title="Sort by Recently Updated"
           tabIndex={0}
+          role="button"
           aria-pressed={sortField === "updated_at"}
           onKeyUp={(e) =>
             e.key === "Enter" && handleSortFieldClick("updated_at")
@@ -123,6 +126,7 @@ const FilterBar: React.FC<FilterBarProps> = ({
           onClick={toggleSortOrder}
           title={`Toggle Sort Order (${sortOrder.toUpperCase()})`}
           tabIndex={0}
+          role="button"
           aria-pressed={sortOrder === "asc"}
           onKeyUp={(e) => e.key === "Enter" && toggleSortOrder()}
         />

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -100,18 +100,31 @@ const FilterBar: React.FC<FilterBarProps> = ({
           }`}
           onClick={() => handleSortFieldClick("stargazers_count")}
           title="Sort by Stargazers"
+          tabIndex={0}
+          aria-pressed={sortField === "stargazers_count"}
+          onKeyUp={(e) =>
+            e.key === "Enter" && handleSortFieldClick("stargazers_count")
+          }
         />
         <FontAwesomeIcon
           icon={faClock}
           className={`sort-icon ${sortField === "updated_at" ? "active" : ""}`}
           onClick={() => handleSortFieldClick("updated_at")}
           title="Sort by Recently Updated"
+          tabIndex={0}
+          aria-pressed={sortField === "updated_at"}
+          onKeyUp={(e) =>
+            e.key === "Enter" && handleSortFieldClick("updated_at")
+          }
         />
         <FontAwesomeIcon
           icon={faSort}
           className="sort-order-toggle"
           onClick={toggleSortOrder}
           title={`Toggle Sort Order (${sortOrder.toUpperCase()})`}
+          tabIndex={0}
+          aria-pressed={sortOrder === "asc"}
+          onKeyUp={(e) => e.key === "Enter" && toggleSortOrder()}
         />
       </div>
     </div>


### PR DESCRIPTION
## 📑 Description
Add keyboard support for filters

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

## Summary by Sourcery

New Features:
- Allow users to navigate and select filter bar sort options using the keyboard.