### PR TITLE
Add link to GStraccini Bot

### DIFF
--- a/src/components/PersonalLinks.tsx
+++ b/src/components/PersonalLinks.tsx
@@ -13,6 +13,7 @@ import "./PersonalLinks.css";
 const links = [
   { name: "Portfolio", url: "https://guilhermebranco.com.br", icon: faGlobe },
   { name: "Old Portfolio", url: "https://zerocool.com.br", icon: faGlobe }, 
+  { name: "GitHub Bot", url: "https://bot.straccini.com", icon: faGithub },
   { name: "Personal Blog", url: "https://blog.guilhermebranco.com.br", icon: faWordpress },
   { name: "Main GitHub", url: "https://github.com/guibranco", icon: faGithub },
   { name: "POCs GitHub", url: "https://github.com/GuilhermeStracini", icon: faGithub },

--- a/tests/components/PersonalLinks.test.tsx
+++ b/tests/components/PersonalLinks.test.tsx
@@ -20,10 +20,11 @@ describe("PersonalLinks component", () => {
 
     // Verify GitHub links
     const githubLinks = screen.getAllByRole("link", { name: /GitHub/i });
-    expect(githubLinks).toHaveLength(2);
+    expect(githubLinks).toHaveLength(3);
 
-    expect(githubLinks[0]).toHaveAttribute("href", "https://github.com/guibranco");
-    expect(githubLinks[1]).toHaveAttribute("href", "https://github.com/GuilhermeStracini");
+    expect(githubLinks[0]).toHaveAttribute("href", "https://bot.straccini.com");
+    expect(githubLinks[1]).toHaveAttribute("href", "https://github.com/guibranco");
+    expect(githubLinks[2]).toHaveAttribute("href", "https://github.com/GuilhermeStracini");
 
     // Verify LinkedIn link
     const linkedInLink = screen.getByRole("link", { name: /LinkedIn/i });


### PR DESCRIPTION
### **User description**
## 📑 Description
Add link to GStraccini Bot

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced a new link to the GitHub Bot in the `PersonalLinks` component.
- This enhances the visibility of the GitHub Bot for users.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PersonalLinks.tsx</strong><dd><code>Add GitHub Bot link to PersonalLinks component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/PersonalLinks.tsx
<li>Added a new link for the GitHub Bot.<br> <li> Updated the list of personal links in the component.<br>


</details>


  </td>
  <td><a href="https://github.com/GuilhermeStracini/guilhermestracini.github.io/pull/45/files#diff-def08d6f003a06499b58bbe3bec13311d6493d16a4ba483d26b0a6da52617f90">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new GitHub Bot link to the personal links section.

- **Tests**
	- Updated test cases to reflect the new GitHub link configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->