### PR TITLE
Remove Personal Blog link from PersonalLinks component

### DIFF
--- a/src/components/PersonalLinks.tsx
+++ b/src/components/PersonalLinks.tsx
@@ -4,7 +4,6 @@ import {
   faGithub,
   faInstagram,
   faLinkedin,
-  faWordpress,
 } from "@fortawesome/free-brands-svg-icons";
 import "./PersonalLinks.css";
 

--- a/src/components/PersonalLinks.tsx
+++ b/src/components/PersonalLinks.tsx
@@ -13,11 +13,6 @@ const links = [
   { name: "Old Portfolio", url: "https://zerocool.com.br", icon: faGlobe },
   { name: "GitHub Bot", url: "https://bot.straccini.com", icon: faGithub },
   {
-    name: "Personal Blog (WordPress)",
-    url: "https://blog.guilhermebranco.com.br",
-    icon: faWordpress,
-  },
-  {
     name: "Tech & Travel Blog",
     url: "https://guilherme.stracini.com.br/blog",
     icon: faBlog,

--- a/tests/components/PersonalLinks.test.tsx
+++ b/tests/components/PersonalLinks.test.tsx
@@ -18,14 +18,7 @@ describe("PersonalLinks component", () => {
     expect(portfolioLinks[1]).toHaveAttribute(
       "href",
       "https://zerocool.com.br",
-    );
-
-    // Verify Personal Blog link
-    const blogLink = screen.getByRole("link", { name: /Personal Blog/i });
-    expect(blogLink).toHaveAttribute(
-      "href",
-      "https://blog.guilhermebranco.com.br",
-    );
+    );   
 
     // Verify GitHub links
     const githubLinks = screen.getAllByRole("link", { name: /GitHub/i });

--- a/tests/components/PersonalLinks.test.tsx
+++ b/tests/components/PersonalLinks.test.tsx
@@ -18,7 +18,7 @@ describe("PersonalLinks component", () => {
     expect(portfolioLinks[1]).toHaveAttribute(
       "href",
       "https://zerocool.com.br",
-    );   
+    );
 
     // Verify GitHub links
     const githubLinks = screen.getAllByRole("link", { name: /GitHub/i });


### PR DESCRIPTION
## 📑 Description
Removed 'Personal Blog (WordPress)' link from the list of personal links.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enhancements:
- Streamline the PersonalLinks list by omitting the Personal Blog (WordPress) link in favor of the remaining active links.